### PR TITLE
added 'else'

### DIFF
--- a/restix.jsx
+++ b/restix.jsx
@@ -48,7 +48,7 @@ $.global.hasOwnProperty('restix') || ( function (HOST, SELF) {
 		if (request.command != "" && request.port != "") {
 			request.fullURL = request.url +  ":" + request.port + "/" + request.command
 		}
-		if (request.command != "") {
+		else if (request.command != "") {
 			request.fullURL = request.url +  "/" + request.command
 		}
 		else {


### PR DESCRIPTION
'else' ergänzt, weil sonst bei gegebenem Command und Port im Request-Objekt der Port nicht in die fullUrl übernommen wird.

var request = {
	url: "http://localhost",
	command: "service",
	port: 55555,
}

vorher: request.fullURL = "http://localhost/service"
nachher: request.fullURL = "http://localhost:55555/service"